### PR TITLE
Remove package attribute from Android Manifests

### DIFF
--- a/navigation/src/main/AndroidManifest.xml
+++ b/navigation/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="uk.co.jamiecruwys.navigation" />
+<manifest />

--- a/ui/src/main/AndroidManifest.xml
+++ b/ui/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="uk.co.jamiecruwys.showcase.ui" />
+<manifest />


### PR DESCRIPTION
Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported, and the value is ignored

```
> Task :ui:processDebugManifest
package="uk.co.jamiecruwys.showcase.ui" found in source AndroidManifest.xml: /home/runner/work/android-showcase/android-showcase/ui/src/main/AndroidManifest.xml.
Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported, and the value is ignored.
Recommendation: remove package="uk.co.jamiecruwys.showcase.ui" from the source AndroidManifest.xml: /home/runner/work/android-showcase/android-showcase/ui/src/main/AndroidManifest.xml.
```

```
> Task :navigation:processDebugManifest
package="uk.co.jamiecruwys.navigation" found in source AndroidManifest.xml: /home/runner/work/android-showcase/android-showcase/navigation/src/main/AndroidManifest.xml.
Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported, and the value is ignored.
Recommendation: remove package="uk.co.jamiecruwys.navigation" from the source AndroidManifest.xml: /home/runner/work/android-showcase/android-showcase/navigation/src/main/AndroidManifest.xml.
```