### PR TITLE
Update annotation processor syntax

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,7 +60,7 @@ dependencies {
 
     debugImplementation(libs.leakcanary)
 
-    annotationProcessor(libs.annotation.glide.compiler)
+    kapt(libs.annotation.glide.compiler)
 
     testImplementation(platform(libs.junit5.bom))
     testImplementation(libs.junit5)


### PR DESCRIPTION
App: 'annotationProcessor' dependencies won't be recognized as kapt annotation processors. Please change the configuration name to 'kapt' for these artifacts: 'com.github.bumptech.glide:compiler:4.14.2'