### PR TITLE
Target sdk is deprecated for libraries

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -141,7 +141,6 @@ fun LibraryExtension.applySharedConfig(moduleName: String) {
 
 fun LibraryDefaultConfig.applySharedConfig(withConsumerProguard: Boolean = false) {
     minSdk = libs.versions.sdk.min.get().toInt()
-    targetSdk = libs.versions.sdk.target.get().toInt()
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     if (withConsumerProguard) {
         consumerProguardFiles("consumer-rules.pro")


### PR DESCRIPTION
```
'targetSdk: Int?' is deprecated. Will be removed from library DSL in v9.0. Use testOptions.targetSdk or/and lint.targetSdk instead
```